### PR TITLE
Remove download_url from setup.py

### DIFF
--- a/mloq/assets/templates/setup.py
+++ b/mloq/assets/templates/setup.py
@@ -22,7 +22,6 @@ setup(
     author="{{author}}",
     author_email="{{author_email}}",
     url="{{url}}",
-    download_url="{{url}}",
     keywords=["Machine learning", "artificial intelligence"],
     tests_require=["pytest>=5.3.5", "hypothesis>=5.6.0"],
     extras_require={},


### PR DESCRIPTION
```
/usr/lib/python3.8/distutils/dist.py:274: UserWarning: Unknown distribution option: 'download_url'
```