### PR TITLE
Add run tests in parallel

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -61,7 +61,7 @@ jobs:
         pip install .
     - name: Test with pytest
       run: |
-        pytest --cov=./ --cov-report=xml
+        make -f scripts/makefile.docker test-codecov
     - name: Upload coverage report
       if: ${{ matrix.python-version=='3.8' }}
       uses: codecov/codecov-action@v1
@@ -129,7 +129,7 @@ jobs:
         run: |
           mv $PROJECT_NAME/tests ./tests
           rm -rf $PROJECT_NAME
-          pytest
+          make -f scripts/makefile.docker test
 
   bump-version:
     name: Bump package version

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PROJECT = mloq
 DOCKER_ORG = fragile
 VERSION ?= latest
 UBUNTU_NAME = $(lsb_release -s -c)
+n ?= auto
 # Project usage commands
 
 .POSIX:
@@ -31,7 +32,7 @@ pipenv-install:
 .PHONY: test
 test:
 	find -name "*.pyc" -delete
-	pytest -s
+	pytest -n $n -s -o log_cli=true -o log_cli_level=info
 
 .PHONY: pipenv-test
 pipenv-test:

--- a/mloq/assets/requirements/requirements-test.txt
+++ b/mloq/assets/requirements/requirements-test.txt
@@ -1,3 +1,5 @@
+psutil==5.8.0
 pytest==6.2.1
-pytest-cov==2.10.1
-hypothesis==5.43.4
+pytest-cov==2.11.1
+pytest-xdist==2.2.0
+hypothesis==6.0.3

--- a/mloq/assets/templates/Makefile
+++ b/mloq/assets/templates/Makefile
@@ -3,6 +3,7 @@ current_dir = $(shell pwd)
 PROJECT = {{project_name}}
 DOCKER_ORG = {{owner}}
 VERSION ?= latest
+n ?= auto
 
 .POSIX:
 style:
@@ -19,7 +20,7 @@ check:
 .PHONY: test
 test:
 	find -name "*.pyc" -delete
-	pytest -s -o log_cli=true -o log_cli_level=info
+	pytest -n $n -s -o log_cli=true -o log_cli_level=info
 
 .PHONY: pipenv-install
 pipenv-install:
@@ -43,7 +44,7 @@ docker-build:
 .PHONY: docker-test
 docker-test:
 	find -name "*.pyc" -delete
-	docker run --rm -it --network host -w /${PROJECT} --entrypoint python3 ${DOCKER_ORG}/${PROJECT}:${VERSION} -m pytest -s -o log_cli=true -o log_cli_level=info
+	docker run --rm -it --network host -w /${PROJECT} --entrypoint python3 ${DOCKER_ORG}/${PROJECT}:${VERSION} -m pytest -n $n -s -o log_cli=true -o log_cli_level=info
 
 .PHONY: docker-shell
 docker-shell:

--- a/mloq/assets/templates/makefile.docker
+++ b/mloq/assets/templates/makefile.docker
@@ -4,6 +4,7 @@ PROJECT = {{project_name}}
 DOCKER_ORG = {{project_org}}
 VERSION ?= latest
 UBUNTU_NAME = $(lsb_release -s -c)
+n ?= auto
 
 # Installation commands used by Dockerfiles
 # Install system packages
@@ -42,6 +43,16 @@ check:
 	pylint ${PROJECT}
 	black --check ${PROJECT}
 
+.PHONY: test
+test:
+	find -name "*.pyc" -delete
+	pytest -n $n -s -o log_cli=true -o log_cli_level=info
+
+.PHONY: test-codecov
+test-codecov:
+	find -name "*.pyc" -delete
+	pytest -n $n -s -o log_cli=true -o log_cli_level=info --cov=./ --cov-report=xml
+
 .PHONY: docker-build
 docker-build:
 	docker build --pull -t ${DOCKER_ORG}/${PROJECT}:${VERSION} .
@@ -49,7 +60,7 @@ docker-build:
 .PHONY: docker-test
 docker-test:
 	find -name "*.pyc" -delete
-	docker run --rm -it --network host -w /${PROJECT} --entrypoint python3 ${DOCKER_ORG}/${PROJECT}:${VERSION} -m pytest -s -o log_cli=true -o log_cli_level=info
+	docker run --rm -it --network host -w /${PROJECT} --entrypoint python3 ${DOCKER_ORG}/${PROJECT}:${VERSION} -m pytest -n $n -s -o log_cli=true -o log_cli_level=info
 
 .PHONY: docker-push
 docker-push:

--- a/mloq/assets/workflows/push-dist.yml
+++ b/mloq/assets/workflows/push-dist.yml
@@ -61,7 +61,7 @@ jobs:
         pip install .
     - name: Test with pytest
       run: |
-        pytest --cov=./ --cov-report=xml
+        make -f scripts/makefile.docker test-codecov
     - name: Upload coverage report
       if: ${{"{{"}} matrix.python-version=='3.8' {{"}}"}}
       uses: codecov/codecov-action@v1
@@ -141,7 +141,7 @@ jobs:
         run: |
           mv $PROJECT_NAME/tests ./tests
           rm -rf $PROJECT_NAME
-          pytest
+          make -f scripts/makefile.docker test
 
   build-wheels:
     name: Build wheels
@@ -251,7 +251,7 @@ jobs:
 
       - name: Test package
         run: |
-          pytest
+          make -f scripts/makefile.docker test
 
   bump-version:
     name: Bump package version

--- a/mloq/assets/workflows/push-python.yml
+++ b/mloq/assets/workflows/push-python.yml
@@ -61,7 +61,7 @@ jobs:
         pip install .
     - name: Test with pytest
       run: |
-        pytest --cov=./ --cov-report=xml
+        make -f scripts/makefile.docker test-codecov
     - name: Upload coverage report
       if: ${{"{{"}} matrix.python-version=='3.8' {{"}}"}}
       uses: codecov/codecov-action@v1
@@ -142,7 +142,7 @@ jobs:
         run: |
           mv $PROJECT_NAME/tests ./tests
           rm -rf $PROJECT_NAME
-          pytest
+          make -f scripts/makefile.docker test
 
   bump-version:
     name: Bump package version

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,5 @@
-pytest==6.1.2
-pytest-cov==2.10.1
-hypothesis==5.43.3
+psutil==5.8.0
+pytest==6.2.1
+pytest-cov==2.11.1
+pytest-xdist==2.2.0
+hypothesis==6.0.3

--- a/scripts/makefile.docker
+++ b/scripts/makefile.docker
@@ -4,6 +4,7 @@ PROJECT = mloq
 DOCKER_ORG = fragile
 VERSION ?= latest
 UBUNTU_NAME = $(lsb_release -s -c)
+n ?= auto
 
 # Installation commands used by Dockerfiles
 # Install system packages
@@ -42,6 +43,16 @@ check:
 	pylint ${PROJECT}
 	black --check ${PROJECT}
 
+.PHONY: test
+test:
+	find -name "*.pyc" -delete
+	pytest -n $n -s -o log_cli=true -o log_cli_level=info
+
+.PHONY: test-codecov
+test-codecov:
+	find -name "*.pyc" -delete
+	pytest -n auto -s -o log_cli=true -o log_cli_level=info --cov=./ --cov-report=xml
+
 .PHONY: docker-build
 docker-build:
 	docker build --pull -t ${DOCKER_ORG}/${PROJECT}:${VERSION} .
@@ -49,7 +60,7 @@ docker-build:
 .PHONY: docker-test
 docker-test:
 	find -name "*.pyc" -delete
-	docker run --rm -it --network host -w /${PROJECT} --entrypoint python3 ${DOCKER_ORG}/${PROJECT}:${VERSION} -m pytest -s -o log_cli=true -o log_cli_level=info
+	docker run --rm -it --network host -w /${PROJECT} --entrypoint python3 ${DOCKER_ORG}/${PROJECT}:${VERSION} -m pytest -n $n -s -o log_cli=true -o log_cli_level=info
 
 .PHONY: docker-push
 docker-push:


### PR DESCRIPTION
Signed-off-by: guillemdb <guillem@fragile.tech>

closes https://github.com/FragileTech/ml-ops-quickstart/issues/38

The tests will run in parallel using all available cpu cores. This behaviour can be changes by changing the environment variable `n` from its default value `n=auto` to `n=desired_number_of_cores`.